### PR TITLE
Fix: Refactored defineStateForms to reduce CCN [#10]

### DIFF
--- a/src/modules/states-generator.ts
+++ b/src/modules/states-generator.ts
@@ -630,167 +630,145 @@ class StatesModule {
     TIME && console.timeEnd("generateDiplomacy");
   }
 
-  // select a forms for listed or all valid states
-  defineStateForms(list: number[] | null = null) {
-    TIME && console.time("defineStateForms");
-    const states = pack.states.filter((s) => s.i && !s.removed && !s.lock);
-    if (states.length < 1) return;
-
-    const generic = { Monarchy: 25, Republic: 2, Union: 1 };
-    const naval = { Monarchy: 25, Republic: 8, Union: 3 };
-
+  getExpTiers(states: State[]){
     const medianState = median(pack.states.map((s) => s.area))!;
     const empireMin = states.map((s) => s.area).sort((a = 0, b = 0) => b - a)[
-      Math.max(Math.ceil(states.length ** 0.4) - 2, 0)
-    ]!;
-    const expTiers = pack.states.map((s) => {
+        Math.max(Math.ceil(states.length ** 0.4) - 2, 0)
+        ]!;
+    return pack.states.map((s) => {
       let tier = Math.min(Math.floor((s.area! / medianState) * 2.6), 4);
       if (tier === 4 && s.area! < empireMin) tier = 3;
       return tier;
     });
+  }
 
-    const monarchy = [
-      "Duchy",
-      "Grand Duchy",
-      "Principality",
-      "Kingdom",
-      "Empire",
-    ]; // per expansionism tier
-    const republic = {
-      Republic: 75,
-      Federation: 4,
-      "Trade Company": 4,
-      "Most Serene Republic": 2,
-      Oligarchy: 2,
-      Tetrarchy: 1,
-      Triumvirate: 1,
-      Diarchy: 1,
-      Junta: 1,
-    }; // weighted random
-    const union = {
-      Union: 3,
-      League: 4,
-      Confederation: 1,
-      "United Kingdom": 1,
-      "United Republic": 1,
-      "United Provinces": 2,
-      Commonwealth: 1,
-      Heptarchy: 1,
-    }; // weighted random
-    const theocracy = {
-      Theocracy: 20,
-      Brotherhood: 1,
-      Thearchy: 2,
-      See: 1,
-      "Holy State": 1,
-    };
-    const anarchy = {
-      "Free Territory": 2,
-      Council: 3,
-      Commune: 1,
-      Community: 1,
-    };
+  stateNotInList(s: State, list: number[] | null = null) {
+    return (list && !list.includes(s.i))
+  }
 
-    for (const s of states) {
-      if (list && !list.includes(s.i)) continue;
-      const tier = expTiers[s.i];
+  decideFormType(s: State, tier: number){
+    const generic = { Monarchy: 25, Republic: 2, Union: 1 };
+    const naval = { Monarchy: 25, Republic: 8, Union: 3 };
 
-      const religion = pack.cells.religion[s.center];
-      const isTheocracy =
+    const religion = pack.cells.religion[s.center];
+    const isTheocracy =
         (religion && pack.religions[religion].expansion === "state") ||
         (P(0.1) &&
-          ["Organized", "Cult"].includes(pack.religions[religion].type));
-      const isAnarchy = P(0.01 - tier / 500);
+            ["Organized", "Cult"].includes(pack.religions[religion].type));
+    const isAnarchy = P(0.01 - tier / 500);
 
-      if (isTheocracy) s.form = "Theocracy";
-      else if (isAnarchy) s.form = "Anarchy";
-      else s.form = s.type === "Naval" ? rw(naval) : rw(generic);
+    if (isTheocracy) s.form = "Theocracy";
+    else if (isAnarchy) s.form = "Anarchy";
+    else s.form = s.type === "Naval" ? rw(naval) : rw(generic);
+  }
 
-      const selectForm = (s: any, tier: number) => {
-        const base = pack.cultures[s.culture].base;
+  // select a forms for listed or all valid states
+  defineStateForms(list: number[] | null = null) {
+    TIME && console.time("defineStateForms");
 
-        if (s.form === "Monarchy") {
-          const form = monarchy[tier];
-          // Default name depends on exponent tier, some culture bases have special names for tiers
-          if (s.diplomacy) {
-            if (
-              form === "Duchy" &&
-              s.neighbors.length > 1 &&
-              rand(6) < s.neighbors.length &&
-              s.diplomacy.includes("Vassal")
-            )
-              return "Marches"; // some vassal duchies on borderland
-            if (base === 1 && P(0.3) && s.diplomacy.includes("Vassal"))
-              return "Dominion"; // English vassals
-            if (P(0.3) && s.diplomacy.includes("Vassal")) return "Protectorate"; // some vassals
-          }
+    const states = pack.states.filter((s) => s.i && !s.removed && !s.lock);
+    if (states.length < 1) return
 
-          if (base === 31 && (form === "Empire" || form === "Kingdom"))
-            return "Khanate"; // Mongolian
-          if (base === 16 && form === "Principality") return "Beylik"; // Turkic
-          if (base === 5 && (form === "Empire" || form === "Kingdom"))
-            return "Tsardom"; // Ruthenian
-          if (base === 16 && (form === "Empire" || form === "Kingdom"))
-            return "Khaganate"; // Turkic
-          if (base === 12 && (form === "Kingdom" || form === "Grand Duchy"))
-            return "Shogunate"; // Japanese
-          if ([18, 17].includes(base) && form === "Empire") return "Caliphate"; // Arabic, Berber
-          if (base === 18 && (form === "Grand Duchy" || form === "Duchy"))
-            return "Emirate"; // Arabic
-          if (base === 7 && (form === "Grand Duchy" || form === "Duchy"))
-            return "Despotate"; // Greek
-          if (base === 31 && (form === "Grand Duchy" || form === "Duchy"))
-            return "Ulus"; // Mongolian
-          if (base === 16 && (form === "Grand Duchy" || form === "Duchy"))
-            return "Horde"; // Turkic
-          if (base === 24 && (form === "Grand Duchy" || form === "Duchy"))
-            return "Satrapy"; // Iranian
-          return form;
-        }
+    const expTiers = this.getExpTiers(states)
 
-        if (s.form === "Republic") {
-          // Default name is from weighted array, special case for small states with only 1 burg
-          if (tier < 2 && s.burgs === 1) {
-            if (
-              trimVowels(s.name) === trimVowels(pack.burgs[s.capital].name!)
-            ) {
-              s.name = pack.burgs[s.capital].name;
-              return "Free City";
-            }
-            if (P(0.3)) return "City-state";
-          }
-          return rw(republic);
-        }
+    const forms = {
+      monarchy: ["Duchy", "Grand Duchy", "Principality", "Kingdom", "Empire",], // per expansionism tier
+      republic: {Republic: 75, Federation: 4, "Trade Company": 4, "Most Serene Republic": 2, Oligarchy: 2, Tetrarchy: 1, Triumvirate: 1, Diarchy: 1, Junta: 1,},// weighted random
+      union: {Union: 3, League: 4, Confederation: 1, "United Kingdom": 1, "United Republic": 1, "United Provinces": 2, Commonwealth: 1, Heptarchy: 1,}, // weighted random
+      theocracy: {Theocracy: 20, Brotherhood: 1, Thearchy: 2, See: 1, "Holy State": 1,},
+      anarchy: {"Free Territory": 2, Council: 3, Commune: 1, Community: 1,}
+    }
 
-        if (s.form === "Union") return rw(union);
-        if (s.form === "Anarchy") return rw(anarchy);
+    for (const s of states) {
+      if (this.stateNotInList(s, list)) continue;
+      const tier = expTiers[s.i];
 
-        if (s.form === "Theocracy") {
-          // European
-          if ([0, 1, 2, 3, 4, 6, 8, 9, 13, 15, 20].includes(base)) {
-            if (P(0.1)) return `Divine ${monarchy[tier]}`;
-            if (tier < 2 && P(0.5)) return "Diocese";
-            if (tier < 2 && P(0.5)) return "Bishopric";
-          }
-          if (P(0.9) && [7, 5].includes(base)) {
-            // Greek, Ruthenian
-            if (tier < 2) return "Eparchy";
-            if (tier === 2) return "Exarchate";
-            if (tier > 2) return "Patriarchate";
-          }
-          if (P(0.9) && [21, 16].includes(base)) return "Imamah"; // Nigerian, Turkish
-          if (tier > 2 && P(0.8) && [18, 17, 28].includes(base))
-            return "Caliphate"; // Arabic, Berber, Swahili
-          return rw(theocracy);
-        }
-      };
-
-      s.formName = selectForm(s, tier);
+      this.decideFormType(s, tier)
+      s.formName = this.selectForm(s, tier, forms);
       s.fullName = this.getFullName(s);
     }
 
     TIME && console.timeEnd("defineStateForms");
   }
+
+  selectForm = (s: any, tier: number, forms: any) => {
+    const base = pack.cultures[s.culture].base;
+
+    if (s.form === "Monarchy") {
+      const form = forms.monarchy[tier];
+      // Default name depends on exponent tier, some culture bases have special names for tiers
+      if (s.diplomacy) {
+        if (
+            form === "Duchy" &&
+            s.neighbors.length > 1 &&
+            rand(6) < s.neighbors.length &&
+            s.diplomacy.includes("Vassal")
+        )
+          return "Marches"; // some vassal duchies on borderland
+        if (base === 1 && P(0.3) && s.diplomacy.includes("Vassal"))
+          return "Dominion"; // English vassals
+        if (P(0.3) && s.diplomacy.includes("Vassal")) return "Protectorate"; // some vassals
+      }
+
+      if (base === 31 && (form === "Empire" || form === "Kingdom"))
+        return "Khanate"; // Mongolian
+      if (base === 16 && form === "Principality") return "Beylik"; // Turkic
+      if (base === 5 && (form === "Empire" || form === "Kingdom"))
+        return "Tsardom"; // Ruthenian
+      if (base === 16 && (form === "Empire" || form === "Kingdom"))
+        return "Khaganate"; // Turkic
+      if (base === 12 && (form === "Kingdom" || form === "Grand Duchy"))
+        return "Shogunate"; // Japanese
+      if ([18, 17].includes(base) && form === "Empire") return "Caliphate"; // Arabic, Berber
+      if (base === 18 && (form === "Grand Duchy" || form === "Duchy"))
+        return "Emirate"; // Arabic
+      if (base === 7 && (form === "Grand Duchy" || form === "Duchy"))
+        return "Despotate"; // Greek
+      if (base === 31 && (form === "Grand Duchy" || form === "Duchy"))
+        return "Ulus"; // Mongolian
+      if (base === 16 && (form === "Grand Duchy" || form === "Duchy"))
+        return "Horde"; // Turkic
+      if (base === 24 && (form === "Grand Duchy" || form === "Duchy"))
+        return "Satrapy"; // Iranian
+      return form;
+    }
+
+    if (s.form === "Republic") {
+      // Default name is from weighted array, special case for small states with only 1 burg
+      if (tier < 2 && s.burgs === 1) {
+        if (
+            trimVowels(s.name) === trimVowels(pack.burgs[s.capital].name!)
+        ) {
+          s.name = pack.burgs[s.capital].name;
+          return "Free City";
+        }
+        if (P(0.3)) return "City-state";
+      }
+      return rw(forms.republic);
+    }
+
+    if (s.form === "Union") return rw(forms.union);
+    if (s.form === "Anarchy") return rw(forms.anarchy);
+
+    if (s.form === "Theocracy") {
+      // European
+      if ([0, 1, 2, 3, 4, 6, 8, 9, 13, 15, 20].includes(base)) {
+        if (P(0.1)) return `Divine ${forms.monarchy[tier]}`;
+        if (tier < 2 && P(0.5)) return "Diocese";
+        if (tier < 2 && P(0.5)) return "Bishopric";
+      }
+      if (P(0.9) && [7, 5].includes(base)) {
+        // Greek, Ruthenian
+        if (tier < 2) return "Eparchy";
+        if (tier === 2) return "Exarchate";
+        if (tier > 2) return "Patriarchate";
+      }
+      if (P(0.9) && [21, 16].includes(base)) return "Imamah"; // Nigerian, Turkish
+      if (tier > 2 && P(0.8) && [18, 17, 28].includes(base))
+        return "Caliphate"; // Arabic, Berber, Swahili
+      return rw(forms.theocracy);
+    }
+};
 
   getFullName(state: State) {
     // state forms requiring Adjective + Name, all other forms use scheme Form + Of + Name


### PR DESCRIPTION
Observing defineStateForms, a bigger part of the function can be granular. 

This effectively reduces the CCN by 53.8%, which is achieved by:

(i) moving stateForms outside of the function 
(ii) moving the expansion tier logic into its own function 
(iii) moving the form and type logic into its own function 
(iv) checking if state is in the list in a separate function.

In summary, the strategy was based on moving parts of code with if statements and conditionals into their own functions.
